### PR TITLE
feat(docmost): extend chart to override defaults and to accommodate extra settings

### DIFF
--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -7,6 +7,7 @@ description: >
 home: https://docmost.com/
 sources:
   - https://github.com/docmost/docmost
+  - https://github.com/thelande/charts
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -21,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/docmost/templates/deployment.yaml
+++ b/charts/docmost/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - bash
             - -c
             - |
-              export DATABASE_URL="postgresql://${PGSQL_DB_USERNAME}:${PGSQL_DB_PASSWORD}@${PGSQL_DB_HOST}/${PGSQL_DB_NAME}?schema=public"
+              export DATABASE_URL="postgresql://${PGSQL_DB_USERNAME}:${PGSQL_DB_PASSWORD}@${PGSQL_DB_HOST}/${PGSQL_DB_NAME}?schema=public{{ .Values.postgres.sslMode }}{{ .Values.postgres.extraParams }}"
               pnpm start
           ports:
             - name: http
@@ -80,6 +80,98 @@ spec:
                   key: appSecret
             - name: REDIS_URL
               value: {{ (required "A redis URL is required" .Values.redis.url) | quote }}
+            {{- if .Values.docmost.debugMode }}
+            - name: DEBUG_MODE
+              value: "true"
+            {{- end }}
+            {{- if .Values.docmost.storage.driver }}
+            - name: STORAGE_DRIVER
+              value: {{ .Values.docmost.storage.driver | quote }}
+            {{- end }}
+            {{- if .Values.docmost.storage.s3.region }}
+            - name: AWS_S3_REGION
+              value: {{ .Values.docmost.storage.s3.region | quote }}
+            {{- end }}
+            {{- if .Values.docmost.storage.s3.bucket }}
+            - name: AWS_S3_BUCKET
+              value: {{ .Values.docmost.storage.s3.bucket | quote }}
+            {{- end }}
+            {{- if .Values.docmost.storage.s3.endpoint }}
+            - name: AWS_S3_ENDPOINT
+              value: {{ .Values.docmost.storage.s3.endpoint | quote }}
+            {{- end }}
+            {{- if .Values.docmost.storage.s3.url }}
+            - name: AWS_S3_URL
+              value: {{ .Values.docmost.storage.s3.url | quote }}
+            {{- end }}
+            {{- if .Values.docmost.storage.s3.forcePathStyle }}
+            - name: AWS_S3_FORCE_PATH_STYLE
+              value: {{ .Values.docmost.storage.s3.forcePathStyle | quote }}
+            {{- end }}
+            {{- if .Values.docmost.storage.s3.existingSecret }}
+            - name: AWS_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.docmost.storage.s3.existingSecret }}
+                  key: access-key-id
+            - name: AWS_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.docmost.storage.s3.existingSecret }}
+                  key: secret-access-key
+            {{- else if .Values.docmost.storage.s3.accessKeyId }}
+            - name: AWS_S3_ACCESS_KEY_ID
+              value: {{ .Values.docmost.storage.s3.accessKeyId | quote }}
+            - name: AWS_S3_SECRET_ACCESS_KEY
+              value: {{ .Values.docmost.storage.s3.secretAccessKey | quote }}
+            {{- end }}
+            {{- if .Values.docmost.fileUploadSizeLimit }}
+            - name: FILE_UPLOAD_SIZE_LIMIT
+              value: {{ .Values.docmost.fileUploadSizeLimit | quote }}
+            {{- end }}
+            {{- if .Values.docmost.fileImportSizeLimit }}
+            - name: FILE_IMPORT_SIZE_LIMIT
+              value: {{ .Values.docmost.fileImportSizeLimit | quote }}
+            {{- end }}
+            {{- if .Values.docmost.drawIO.url }}
+            - name: DRAWIO_URL
+              value: {{ .Values.docmost.drawIO.url | quote }}
+            {{- end }}
+            {{- if .Values.docmost.oidc.buttonText }}
+            - name: OIDC_BUTTON_TEXT
+              value: {{ .Values.docmost.oidc.buttonText | quote }}
+            {{- end }}
+            {{- if .Values.docmost.oidc.autoRedirect }}
+            - name: OIDC_AUTO_REDIRECT
+              value: "true"
+            {{- end }}
+            {{- if .Values.docmost.jwtTokenExpiresIn }}
+            - name: JWT_TOKEN_EXPIRES_IN
+              value: {{ .Values.docmost.jwtTokenExpiresIn | quote }}
+            {{- end }}
+            {{- if .Values.docmost.databaseMaxPool }}
+            - name: DATABASE_MAX_POOL
+              value: {{ .Values.docmost.databaseMaxPool | quote }}
+            {{- end }}
+            {{- if .Values.docmost.disableTelemetry }}
+            - name: DISABLE_TELEMETRY
+              value: "true"
+            {{- end }}
+            {{- if .Values.docmost.port }}
+            - name: PORT
+              value: {{ .Values.docmost.port | quote }}
+            {{- end }}
+            {{- if .Values.docmost.posthogHost }}
+            - name: POSTHOG_HOST
+              value: {{ .Values.docmost.posthogHost | quote }}
+            {{- end }}
+            {{- if .Values.docmost.posthogKey }}
+            - name: POSTHOG_KEY
+              value: {{ .Values.docmost.posthogKey | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- if .Values.docmost.smtp.enabled }}
             - name: MAIL_DRIVER
               value: smtp
@@ -89,6 +181,16 @@ spec:
               value: {{ .Values.docmost.smtp.port | quote }}
             - name: SMTP_SECURE
               value: {{ .Values.docmost.smtp.secure | quote }}
+            {{- if .Values.docmost.smtp.ignoreTls }}
+            - name: SMTP_IGNORETLS
+              value: "true"
+            {{- end }}
+            {{- if .Values.docmost.postmark.token }}
+            - name: MAIL_DRIVER
+              value: postmark
+            - name: POSTMARK_TOKEN
+              value: {{ .Values.docmost.postmark.token | quote }}
+            {{- end }}
             - name: MAIL_FROM_ADDRESS
               value: {{ (required "Mail from address is required." .Values.docmost.smtp.mailFrom.address) | quote }}
             - name: MAIL_FROM_NAME
@@ -104,6 +206,10 @@ spec:
                   name: {{ include "docmost.smtp.auth.secretName" . }}
                   key: password
             {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /app/data/storage

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -127,6 +127,10 @@ persistence:
 postgres:
   # -- PostgreSQL cluster details secret name
   appSecretName: "postgres-cluster-app"
+  # -- PostgreSQL SSL mode (e.g., "&sslmode=require", "&sslmode=verify-full")
+  sslMode: ""
+  # -- Additional PostgreSQL connection parameters (e.g., "&connect_timeout=10")
+  extraParams: ""
 
 redis:
   # -- Redis cluster URL
@@ -135,10 +139,18 @@ redis:
 docmost:
   # -- docmost externally accessible URL
   appUrl: ""
+  # -- Enable debug mode (default: false)
+  debugMode: false
 
   drawIO:
     # -- Custom draw.io server url.
     url: ""
+
+  oidc:
+    # -- OIDC button text (default: "Sign in with SSO")
+    buttonText: ""
+    # -- Auto-redirect to OIDC when SSO is enforced (default: false)
+    autoRedirect: false
 
   smtp:
     # -- Should SMTP be enabled?
@@ -164,3 +176,68 @@ docmost:
       password: ""
       # -- An existing secret containing the SMTP server username and password.
       existingSecret: ""
+
+    # -- SMTP ignore TLS (default: false)
+    ignoreTls: false
+
+  postmark:
+    # -- Postmark API token (alternative to SMTP)
+    token: ""
+
+  storage:
+    # -- Storage driver (local or s3)
+    driver: ""
+    s3:
+      # -- AWS S3 region
+      region: ""
+      # -- S3 bucket name
+      bucket: ""
+      # -- S3 endpoint URL
+      endpoint: ""
+      # -- S3 public URL
+      url: ""
+      # -- Force path style (true/false)
+      forcePathStyle: ""
+      # -- Existing secret containing AWS credentials (access-key-id, secret-access-key)
+      existingSecret: ""
+      # -- AWS access key ID (if not using existingSecret)
+      accessKeyId: ""
+      # -- AWS secret access key (if not using existingSecret)
+      secretAccessKey: ""
+
+  # -- File upload size limit (e.g., "50mb", "1gb")
+  fileUploadSizeLimit: ""
+  # -- File import size limit (e.g., "200mb")
+  fileImportSizeLimit: ""
+
+  # -- JWT token expiration (default: "90d")
+  jwtTokenExpiresIn: ""
+
+  # -- Database max pool size (default: 10)
+  databaseMaxPool: ""
+
+  # -- Application port (default: 3000)
+  port: ""
+
+  # -- Disable telemetry (default: false)
+  disableTelemetry: false
+
+  # -- PostHog analytics host
+  posthogHost: ""
+
+  # -- PostHog analytics key
+  posthogKey: ""
+
+# -- Additional environment variables (name/value pairs)
+extraEnv: []
+# - name: NODE_TLS_REJECT_UNAUTHORIZED
+#   value: "0"
+# - name: CUSTOM_VAR
+#   value: "custom_value"
+
+# -- Additional environment variables from secrets or configmaps
+extraEnvFrom: []
+# - secretRef:
+#     name: additional-secrets
+# - configMapRef:
+#     name: additional-config


### PR DESCRIPTION
- Introducing options already existing in docmost code base in OSS version
- Adding `extraEnv` and `extraEnvFrom` to accommodate for extra settings
- Adding SSL option for PostgreSQL database, as those are mandatory in my environment
- All newly introduces settings are optional and reference the actual defaults from docmost code base